### PR TITLE
Fix LTO build

### DIFF
--- a/src/Droplet.hpp
+++ b/src/Droplet.hpp
@@ -17,6 +17,8 @@
 #define SLIDEREDITNOTE_LPF 0.980
 #define CENTER_PLATEAU 80
 
+namespace droplet {
+
 enum FilterSetting {
 	TwoPass = 0,
 	OnePass
@@ -29,8 +31,6 @@ enum EnvelopeMode {
 };
 
 uint32_t diff(uint32_t a, uint32_t b);
-
-namespace droplet {
 
 struct Audio;
 struct Filter;

--- a/src/Rainbow.hpp
+++ b/src/Rainbow.hpp
@@ -34,6 +34,14 @@
 #define SLIDEREDITNOTE_LPF 0.980
 #define CENTER_PLATEAU 80
 
+struct RainbowScaleExpanderMessage {
+	float maxq48[NUM_BANKNOTES];
+	float maxq96[NUM_BANKNOTES];
+	bool updated;
+};
+
+namespace rainbow {
+
 enum FilterModes {
 	TWOPASS = 2,
 	ONEPASS = 3
@@ -83,14 +91,6 @@ enum EnvelopeMode {
 };
 
 uint32_t diff(uint32_t a, uint32_t b);
-
-struct RainbowScaleExpanderMessage {
-	float maxq48[NUM_BANKNOTES];
-	float maxq96[NUM_BANKNOTES];
-	bool updated;
-};
-
-namespace rainbow {
 
 struct TFilter;
 struct MaxQFilter;


### PR DESCRIPTION
When building Prism with LTO enabled (link-time optimization, for faster binaries), the final step complains about "One Definition Rule", which is typically a sign of problem when using LTO.

```
Prism/src/Rainbow.hpp:58: error: type 'FilterSetting' violates the C++ One Definition Rule [-Werror=odr]
Prism/src/Droplet.hpp:20: note: an enum with mismatching number of values is defined in another translation unit
```

The issue happens because the same `FilterSetting` enum is defined in 2 different places with different contents.
When linking the binary with all objects together with LTO, the different enums will conflict.

Since the code already has C++ namespaces in place, simply moving the common definitons inside the namespace fixes the issue, so it then becomes `droplet::FilterSetting` and `rainbow::FilterSetting`, thus no more conflicts :tada: 
