### PR TITLE
Remove wrong include

### DIFF
--- a/src/Droplet.cpp
+++ b/src/Droplet.cpp
@@ -1,4 +1,3 @@
-#include "common.hpp"
 
 #include "plugin.hpp"
 #include "Common.hpp"

--- a/src/Rainbow.cpp
+++ b/src/Rainbow.cpp
@@ -1,7 +1,5 @@
 #include <bitset>
 
-#include "common.hpp"
-
 #include "plugin.hpp"
 #include "Common.hpp"
 #include "Rainbow.hpp"

--- a/src/RainbowExpander.cpp
+++ b/src/RainbowExpander.cpp
@@ -10,8 +10,6 @@
 #include <cctype>
 #include <osdialog.h>
 
-#include "common.hpp"
-
 #include "plugin.hpp"
 #include "Common.hpp"
 #include "Rainbow.hpp"


### PR DESCRIPTION
Seen under macOS:

```
Prism/src/RainbowExpander.cpp:13:10: warning: non-portable path to file '"Common.hpp"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include "common.hpp"
         ^~~~~~~~~~~~
         "Common.hpp"
```

There is a "Common.hpp" include a few lines below, so this include usage is weird.
Under typical macOS and Windows, due to non-case-sensitive FS, both statements will include the same file.

We can safely remove the first include, silencing the compiler warning.
