### PR TITLE
Adjust for Cardinal light mode

### DIFF
--- a/src/Common.hpp
+++ b/src/Common.hpp
@@ -270,7 +270,12 @@ struct FloatReadout : PrismReadoutParam {
 			char text[128];
 
 			nvgFontSize(ctx.vg, 14.0f);
-			nvgFillColor(ctx.vg, nvgRGBA(0xBE, 0xBE, 0xBE, 0xFF));
+			#ifdef USING_CARDINAL_NOT_RACK
+			if (!settings::darkMode)
+				nvgFillColor(ctx.vg, nvgRGBA(0x41, 0x41, 0x41, 0xFF));
+			else
+			#endif
+				nvgFillColor(ctx.vg, nvgRGBA(0xBE, 0xBE, 0xBE, 0xFF));
 			snprintf(text, sizeof(text), "%s", title.c_str());
 			nvgText(ctx.vg, pos.x, pos.y, text, NULL);
 
@@ -307,8 +312,12 @@ struct IntegerReadout : PrismReadoutParam {
 			nvgFontFaceId(ctx.vg, font->handle);
 
 			char text[128];
-
-			nvgFillColor(ctx.vg, nvgRGBA(0xBE, 0xBE, 0xBE, 0xFF));
+			#ifdef USING_CARDINAL_NOT_RACK
+			if (!settings::darkMode)
+				nvgFillColor(ctx.vg, nvgRGBA(0x41, 0x41, 0x41, 0xFF));
+			else
+			#endif
+				nvgFillColor(ctx.vg, nvgRGBA(0xBE, 0xBE, 0xBE, 0xFF));
 			snprintf(text, sizeof(text), "%s", title.c_str());
 			nvgText(ctx.vg, pos.x, pos.y, text, NULL);
 


### PR DESCRIPTION
With Cardinal 22.09 a "light" mode is coming, per common user request. So users can toggle between light and dark mode.
A few modules that are always dark need tweaking, Prism being one of them.
Changed code does not affect regular VCV Rack module. And only needed because text color is hardcoded in C++ file, making it harder to invert at runtime.

Regular dark mode look:

![image](https://user-images.githubusercontent.com/1334853/190161255-a4963817-ba43-4667-9027-16fb6aa94412.png)

New light mode look:

![image](https://user-images.githubusercontent.com/1334853/190161370-18aed5b9-a839-420f-a334-bf5b4e57e3e8.png)
